### PR TITLE
Don't auto-generate the 3rd position of version number

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 2.0.{build}
+version: 2.1.0.{build}
 image: Visual Studio 2017
 
 artifacts:

--- a/toofz.NecroDancer.Leaderboards.PlayersService/Properties/AssemblyInfo.cs
+++ b/toofz.NecroDancer.Leaderboards.PlayersService/Properties/AssemblyInfo.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("toofz Players Service")]
 [assembly: AssemblyCopyright("Copyright © Leonard Thieu 2015")]
 [assembly: ComVisible(false)]
-[assembly: AssemblyVersion("2.0.*")]
+[assembly: AssemblyVersion("2.1.0.*")]
 
 [assembly: InternalsVisibleTo("toofz.NecroDancer.Leaderboards.PlayersService.Tests")]
 


### PR DESCRIPTION
The first 3 positions are used in determining if a major upgrade is possible in the installer. This change makes it easier to manage version numbers with respect to upgrading installations.