### PR TITLE
Fix decoding error when receiving responses from toofz API

### DIFF
--- a/toofz.NecroDancer.Leaderboards.PlayersService/WorkerRole.cs
+++ b/toofz.NecroDancer.Leaderboards.PlayersService/WorkerRole.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -25,7 +26,10 @@ namespace toofz.NecroDancer.Leaderboards.PlayersService
         protected override void OnStartOverride()
         {
             oAuth2Handler = new OAuth2Handler();
-            apiHandlers = HttpClientFactory.CreatePipeline(new WebRequestHandler(), new DelegatingHandler[]
+            apiHandlers = HttpClientFactory.CreatePipeline(new WebRequestHandler
+            {
+                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+            }, new DelegatingHandler[]
             {
                 new LoggingHandler(),
                 new HttpRequestStatusHandler(),


### PR DESCRIPTION
This error occurs because responses were not decompressed prior to reading them.

```
System.Text.DecoderFallbackException was unhandled
  BytesUnknown=System.Byte[]
  HResult=-2147024809
  Index=1
  Message=Unable to translate bytes [8B] at index 1 from specified code page to Unicode.
  Source=mscorlib
  StackTrace:
    System.Text.DecoderExceptionFallbackBuffer.Throw(Byte[] bytesUnknown, Int32 index)
    System.Text.DecoderExceptionFallbackBuffer.Fallback(Byte[] bytesUnknown, Int32 index)
    System.Text.DecoderFallbackBuffer.InternalFallback(Byte[] bytes, Byte* pBytes, Char*& chars)
    System.Text.UTF8Encoding.GetChars(Byte* bytes, Int32 byteCount, Char* chars, Int32 charCount, DecoderNLS baseDecoder)
    System.Text.DecoderNLS.GetChars(Byte* bytes, Int32 byteCount, Char* chars, Int32 charCount, Boolean flush)
    System.Text.DecoderNLS.GetChars(Byte[] bytes, Int32 byteIndex, Int32 byteCount, Char[] chars, Int32 charIndex, Boolean flush)
    System.Text.DecoderNLS.GetChars(Byte[] bytes, Int32 byteIndex, Int32 byteCount, Char[] chars, Int32 charIndex)
    System.IO.StreamReader.ReadBuffer(Char[] userBuffer, Int32 userOffset, Int32 desiredChars, Boolean& readToUserBuffer)
    System.IO.StreamReader.Read(Char[] buffer, Int32 index, Int32 count)
    Newtonsoft.Json.JsonTextReader.ReadData(Boolean append, Int32 charsRequired)
    Newtonsoft.Json.JsonTextReader.ParseValue()
    Newtonsoft.Json.JsonTextReader.Read()
    Newtonsoft.Json.JsonReader.ReadForType(JsonContract contract, Boolean hasConverter)
    Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
    Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
    System.Net.Http.Formatting.BaseJsonMediaTypeFormatter.ReadFromStream(Type type, Stream readStream, Encoding effectiveEncoding, IFormatterLogger formatterLogger)
    System.Net.Http.Formatting.JsonMediaTypeFormatter.ReadFromStream(Type type, Stream readStream, Encoding effectiveEncoding, IFormatterLogger formatterLogger)
    System.Net.Http.Formatting.BaseJsonMediaTypeFormatter.ReadFromStream(Type type, Stream readStream, HttpContent content, IFormatterLogger formatterLogger)
    System.Net.Http.Formatting.BaseJsonMediaTypeFormatter.ReadFromStreamAsync(Type type, Stream readStream, HttpContent content, IFormatterLogger formatterLogger)
    System.Net.Http.HttpContentExtensions.<ReadAsAsyncCore>d__0`1.MoveNext()
    toofz.NecroDancer.Leaderboards.toofz.ToofzApiClient.<GetPlayersAsync>d__2.MoveNext()
    toofz.NecroDancer.Leaderboards.PlayersService.WorkerRole.<UpdatePlayersAsync>d__6.MoveNext() in S:\Projects\_toofz\players-service\toofz.NecroDancer.Leaderboards.PlayersService\WorkerRole.cs:line 80
    toofz.NecroDancer.Leaderboards.PlayersService.WorkerRole.<RunAsyncOverride>d__5.MoveNext() in S:\Projects\_toofz\players-service\toofz.NecroDancer.Leaderboards.PlayersService\WorkerRole.cs:line 56
    toofz.NecroDancer.Leaderboards.Services.Common.WorkerRoleBase`1.<RunAsync>d__14.MoveNext() in C:\projects\toofz-necrodancer-leaderboards-services-common\toofz.NecroDancer.Leaderboards.Services.Common\WorkerRoleBase.cs:line 131
```