### PR TITLE
Ensure PDBs are packaged with installer.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,8 @@ test_script:
           /target:Rebuild `
           /target:Test `
           /property:Configuration=Coverage `
-          /property:DebugType=full
+          /property:DebugType=full `
+          /property:PublishCoverage=false
       
 artifacts:
   - path: \src\Installer\bin\$(Configuration)\*.msi

--- a/src/PlayersService/PlayersService.csproj
+++ b/src/PlayersService/PlayersService.csproj
@@ -49,4 +49,18 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+
+  <!-- https://github.com/dotnet/sdk/issues/1458#issuecomment-401497095 -->
+  <Target Name="_ResolveCopyLocalNuGetPackagePdbsAndXml"
+          Condition="$(CopyLocalLockFileAssemblies) == true"
+          AfterTargets="ResolveReferences">
+    <ItemGroup>
+      <ReferenceCopyLocalPaths Include="@(ReferenceCopyLocalPaths->'%(RootDir)%(Directory)%(Filename).pdb')"
+                               Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' != ''
+                                          and Exists('%(RootDir)%(Directory)%(Filename).pdb')" />
+      <ReferenceCopyLocalPaths Include="@(ReferenceCopyLocalPaths->'%(RootDir)%(Directory)%(Filename).xml')"
+                               Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' != ''
+                                          and Exists('%(RootDir)%(Directory)%(Filename).xml')" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
The old workaround to include PDBs in the installer stopped working, likely due to a change in tooling. This change should be properly integrated into toofz.Build at some point.